### PR TITLE
Fitbit server done

### DIFF
--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"log"
+	"net/http"
+	"os"
 )
+
+var params authParams
 
 type authParams struct {
 	client_id string
@@ -19,11 +22,14 @@ func answer(w http.ResponseWriter, r *http.Request) {
 }
 
 func register(w http.ResponseWriter, r *http.Request) {
+	var registerUrl = "https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=" + params.client_id +
+		"&redirect_uri=phewstoc.sladic.se/success/&scope=sleep"
 	http.Redirect(w, r, registerUrl, http.StatusSeeOther)
 }
 
 func success(w http.ResponseWriter, r *http.Request)  {
-
+	fmt.Print(r)
+	fmt.Fprintf(w, "Received! :)")
 }
 
 func fitbitData(w http.ResponseWriter, r *http.Request) {
@@ -31,10 +37,13 @@ func fitbitData(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	params = authParams{os.Args[1], os.Args[2], os.Args[3], os.Args[4]}
+
 	http.HandleFunc("/", answer)
 	http.HandleFunc("/register/", register)
 	http.HandleFunc("/register/success", success)
 	http.HandleFunc("/subscribe/sleep/", fitbitData)
+
 	err := http.ListenAndServe(":9090", nil)
 	if err != nil {
 		log.Fatal("listenAndServe: ", err)

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -140,6 +140,10 @@ func isSleeping(w http.ResponseWriter, r *http.Request) {
 	lowerbpm := findLowerHeartBeat()
 	upperbpm := findUpperHeartBeat()
 
+	if lowerbpm == nil {
+		w.WriteHeader(http.StatusNoContent)
+	}
+
 	if upperbpm - upperbpm <= 20 && upperbpm <= 70 { // Test case (original value might be 10 & 50)
 		w.WriteHeader(418) // Person is sleeping
 	} else {
@@ -147,9 +151,9 @@ func isSleeping(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func findLowerHeartBeat() {
+func findLowerHeartBeat() int {
 	lower := nil
-	for _, rate := range heartRateData.ActivityHeartIntraday.HeartIntradayDatapoint {
+	for _, rate := range heartRateData.ActivityHeartIntraday.HeartIntradayDatapoint.HeartRate {
 		if lower > rate || lower == nil {
 			lower = rate
 		}
@@ -157,9 +161,9 @@ func findLowerHeartBeat() {
 	return lower
 }
 
-func findUpperHeartBeat() {
+func findUpperHeartBeat() int {
 	upper := nil
-	for _, rate := range heartRateData.ActivityHeartIntraday.HeartIntradayDatapoint {
+	for _, rate := range heartRateData.ActivityHeartIntraday.HeartIntradayDatapoint.HeartRate {
 		if upper < rate || upper == nil {
 			upper = rate
 		}

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -5,6 +5,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+    b64 "encoding/base64"
+
+    "github.com/satori/go.uuid"
 )
 
 var params authParams
@@ -26,9 +29,26 @@ func register(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, registerUrl, http.StatusSeeOther)
 }
 
+func concAuth(clientId string, clientSecret string) string {
+    idAndSecret := clientId + ":" + client
+    return b64.StdEncoding.EncodeToString([]byte(idAndSecret))
+}
+
 func success(w http.ResponseWriter, r *http.Request)  {
 	fmt.Print(r)
 	fmt.Fprintf(w, "Received! :)")
+
+    keys, err := r.URL.Query()['code']
+    if err != nil {
+        log.Println("Url param 'code' is missing")
+    }
+
+    
+
+    authURL := "https://api.fitbit.com/oauth2/token"
+    req, err := http.NewRequest("POST", authURL, )
+    req.Header.Set("Authorization", "Basic " + concAuth(clientId, clientSecret))
+    req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 }
 
 func fitbitData(w http.ResponseWriter, r *http.Request) {

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -22,8 +22,7 @@ func answer(w http.ResponseWriter, r *http.Request) {
 }
 
 func register(w http.ResponseWriter, r *http.Request) {
-	var registerUrl = "https://www.fitbit.com/oauth2/authorize?response_type=code&client_id="
-	+ params.client_id + "&scope=sleep"
+	var registerUrl = "https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=" + params.client_id + "&scope=sleep"
 	http.Redirect(w, r, registerUrl, http.StatusSeeOther)
 }
 
@@ -45,7 +44,7 @@ func main() {
 	http.HandleFunc("/subscribe/sleep/", fitbitData)
 
 	//err := http.ListenAndServeTLS(":9090", "server.crt", "server.key", nil)
-	err := http.listenAndServe("9090")
+	err := http.ListenAndServe("443", nil)
 	if err != nil {
 		log.Fatal("listenAndServe: ", err)
 	}

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -79,7 +79,7 @@ func authOnSuccess(w http.ResponseWriter, r *http.Request) {
 	v.Add("grant_type", "authorization_code")
 	v.Add("code", keys[0])
 
-    req, err := http.NewRequest("POST", authURL, strings.NewReader(v.Encode()))
+  req, err := http.NewRequest("POST", authURL, strings.NewReader(v.Encode()))
 	if err != nil {
 		fmt.Println("authentication error while obtaining acesstoken")
 	}
@@ -101,6 +101,7 @@ func authOnSuccess(w http.ResponseWriter, r *http.Request) {
 	} else {
 		params.refresh_token = accessTokenInfo.RefreshToken
 	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func getHeartRateData() Heart {
@@ -132,9 +133,11 @@ func isSleeping(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if upperbpm - upperbpm <= 20 && upperbpm <= 70 { // Test case (original value might be 10 & 50)
-		w.WriteHeader(418) // Person is sleeping
+		//.WriteHeader(418) // Person is sleeping
+		fmt.Fprintf(w, "Person is sleeping.")
 	} else {
-		w.WriteHeader(200) // Person is awake
+		//w.WriteHeader(200) // Person is awake
+		fmt.Fprintf(w, "Person is not sleeping.")
 	}
 }
 
@@ -164,7 +167,7 @@ func main() {
 	http.HandleFunc("/", welcomeMessage)
 	http.HandleFunc("/register/", register)
 	http.HandleFunc("/success/", authOnSuccess)
-	http.HandleFunc("/is_sleeping/", isSleeping)
+	http.HandleFunc("/issleeping/", isSleeping)
 
 	err := http.ListenAndServeTLS(":443", "/etc/letsencrypt/live/phewstoc.sladic.se/fullchain.pem", "/etc/letsencrypt/live/phewstoc.sladic.se/privkey.pem", nil)
 	if err != nil {

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -40,7 +40,7 @@ func main() {
 
 	http.HandleFunc("/", answer)
 	http.HandleFunc("/register/", register)
-	http.HandleFunc("/register/success", success)
+	http.HandleFunc("/success/", success)
 	http.HandleFunc("/subscribe/sleep/", fitbitData)
 
 	err := http.ListenAndServeTLS(":443", "/etc/letsencrypt/live/phewstoc.sladic.se/fullchain.pem", "/etc/letsencrypt/live/phewstoc.sladic.se/privkey.pem", nil)

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -17,9 +17,6 @@ var params authParams
 type authParams struct {
 	client_id     string
 	client_secret string
-	response_type string
-	scope         string
-	redirect_uri  string
 	refresh_token string
 }
 
@@ -208,7 +205,7 @@ func refreshToken() {
 }
 
 func main() {
-	params = authParams{os.Args[1], os.Args[2], os.Args[3], os.Args[4], os.Args[5], os.Args[6]}
+	params = authParams{os.Args[1], os.Args[2]}
 
 	http.HandleFunc("/", welcomeMessage)
 	http.HandleFunc("/register/", register)

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -12,13 +12,22 @@ import (
 )
 
 var params authParams
-
 type authParams struct {
 	client_id     string
 	client_secret string
 	response_type string
 	scope         string
 	redirect_uri  string
+	refresh_token string
+}
+
+var accessTokenInfo ResponseInfo
+type ResponseInfo struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	UserId       string `json:"user_id"`
 }
 
 func welcomeMessage(w http.ResponseWriter, r *http.Request) {
@@ -41,6 +50,15 @@ type Calorie float64
 
 type Heart struct {
 	ActivitiesHeartIntraday ActivityHeartIntraday `json:"activities-heart-intraday"`
+	ActivitiesHeart 				ActivitiesHeart				`json:"activities-heart"`
+}
+
+type ActivitiesHeart struct {
+	Dataset  []RestingHeartRate `json:"dataset"`
+}
+
+type RestingHeartRate struct {
+	HeartRate HeartRate `json:"restingHeartRate"`
 }
 
 type ActivityHeartIntraday struct {
@@ -85,21 +103,22 @@ func authOnSuccess(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fmt.Println(resp.Status)
-	type ResponseInfo struct {
-		AccessToken  string `json:"access_token"`
-		ExpiresIn    int    `json:"expires_in"`
-		RefreshToken string `json:"refresh_token"`
-		TokenType    string `json:"token_type"`
-		UserId       string `json:"user_id"`
-	}
-	var accessTokenInfo ResponseInfo
+
 	err = json.NewDecoder(resp.Body).Decode(&accessTokenInfo)
 	if err != nil {
 		fmt.Println("error:", err)
+	} else {
+		authParams.refresh_token = accessTokenInfo.RefreshToken
 	}
-	fmt.Println(accessTokenInfo)
+	//fmt.Println(accessTokenInfo)
+	heartRate := getHeartRateData()
+	fmt.Fprint(w, heartRate.Heart)
+	//fmt.Fprint(w, heartRate.ActivitiesHeartIntraday)
+	//fmt.Fprint(w, heartRate.ActivitiesHeart)
+}
 
-    reqURL := "https://api.fitbit.com/1/user/" + accessTokenInfo.UserId + "/activities/heart/date/today/1d/1sec/time/05:00/05:01.json"
+func getHeartRateData() Heart {
+	reqURL := "https://api.fitbit.com/1/user/" + accessTokenInfo.UserId + "/activities/heart/date/today/1d/1sec/time/05:00/05:01.json"
 	getReq, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
 		fmt.Println("some get reqq err")
@@ -113,17 +132,48 @@ func authOnSuccess(w http.ResponseWriter, r *http.Request) {
 	fmt.Println(getResp.Status)
 
 	var heartRate Heart
-	//	body, err := ioutil.ReadAll(getResp.Body)
-	//	fmt.Println(string(body))
 	err = json.NewDecoder(getResp.Body).Decode(&heartRate)
-	fmt.Fprint(w, heartRate.ActivitiesHeartIntraday)
-	// fmt.Println(sleepLog.Sleep[0].Data)
-	// fmt.Fprint(w, getResp)
-	// fmt.Println(resp)
+	return heartRate
 }
 
 func fitbitData(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func refreshToken(w http.ResponseWriter, r *http.Request) {
+	client := &http.Client{}
+
+	v := url.Values{}
+	v.Add("grant_type", "authorization_code")
+	v.Add("refresh_token", authParams.refresh_token)
+
+	req, err := http.NewRequest("POST", "https://api.fitbit.com/oauth2/token", strings.NewReader(v.Encode()))
+	if err != nill {
+		fmt.Println("Unable to create request.")
+	}
+
+	req.Header.Set("Authorization", "Basic "+concAuth(params.client_id, params.client_secret))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		fmt.Println("some client Do err")
+	}
+}
+
+func isSleeping(w http.ResponseWriter, r *http.Request) {
+	// Call on register to retrive data from FitBit
+
+	lowerbpm := findLowerHeartBeat()
+	upperbpm := findUpperHeartBeat()
+	timespan := findTimespanHeartBeat()
+
+	if upperbpm - upperbpm <= 10 && timespan <= 10 {
+		// return true
+	} else {
+		// return false
+	}
 }
 
 func main() {
@@ -133,6 +183,8 @@ func main() {
 	http.HandleFunc("/register/", register)
 	http.HandleFunc("/success/", authOnSuccess)
 	http.HandleFunc("/subscribe/sleep/", fitbitData)
+	http.HandleFunc("/refresh_token/", refreshToken)
+	http.HandleFunc("/is_sleeping/", isSleeping)
 
 	err := http.ListenAndServeTLS(":443", "/etc/letsencrypt/live/phewstoc.sladic.se/fullchain.pem", "/etc/letsencrypt/live/phewstoc.sladic.se/privkey.pem", nil)
 	if err != nil {

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -80,49 +80,6 @@ type HeartIntradayDatapoint struct {
 	HeartRate HeartRate `json:"value"`
 }
 
-type Sleep struct {
-	Sleep []SleepDatapoint `json:"sleep"`
-}
-
-type SleepDatapoint struct {
-	Data                string      `json:"dateOfSleep"`
-	Duration            int         `json:"duration"`
-	Efficiency          int         `json:"efficiency"`
-	IsMainSleep         bool        `json:"isMainSleep"`
-	Levels              SleepLevels `json:"levels"`
-	LogId               int         `json:"logId"`
-	MinutesAfterWakeup  int         `json:"minutesAfterWakeup"`
-	MinutesAsleep       int         `json:"minutesAsleep"`
-	MinutesAwake        int         `json:"minutesAwake"`
-	MinutesToFallAsleep int         `json:"minutesToFallAsleep"`
-	StartTime           string      `json:"startTime"`
-	TimeInBed           int         `json:"timeInBed"`
-	Type                string      `json:"type"`
-}
-
-type SleepLevels struct {
-	Summary   SleepLevelsSummary     `json:"summary"`
-	Data      []SleepLevelsDatapoint `json:"data"`
-	ShortData []SleepLevelsDatapoint `json:"shortData"`
-}
-
-type SleepLevelsSummary struct {
-	Deep  SleepLevel `json:"deep"`
-	Light SleepLevel `json:"light"`
-	Rem   SleepLevel `json:"rem"`
-	Wake  SleepLevel `json:"wake"`
-}
-type SleepLevel struct {
-	Count           int `json:"count"`
-	Minutes         int `json:"minutes"`
-	AvgMinutes30Day int `json:"thirtyDayAvgMinutes"`
-}
-
-type SleepLevelsDatapoint struct {
-	Datetime string `json:"datetime"`
-	Level    string `json:"level"`
-	Duration int    `json:"seconds"`
-}
 
 func success(w http.ResponseWriter, r *http.Request) {
 	fmt.Print(r)
@@ -166,7 +123,7 @@ func success(w http.ResponseWriter, r *http.Request) {
 	}
 	fmt.Println(accessTokenInfo)
 
-	reqURL := "https://api.fitbit.com/1.2/user/" + accessTokenInfo.UserId + "/sleep/date/2019-02-22.json"
+	reqURL := "https://api.fitbit.com/1.2/user/" + accessTokenInfo.UserId + "/activities/heart/date/today/1d/1sec.json"
 	getReq, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
 		fmt.Println("some get reqq err")
@@ -179,11 +136,11 @@ func success(w http.ResponseWriter, r *http.Request) {
 	}
 	fmt.Println(getResp.Status)
 
-	var sleepLog Sleep
+	var heartRate Heart
 	//	body, err := ioutil.ReadAll(getResp.Body)
 	//	fmt.Println(string(body))
-	err = json.NewDecoder(getResp.Body).Decode(&sleepLog)
-	fmt.Fprint(w, sleepLog)
+	err = json.NewDecoder(getResp.Body).Decode(&heartRate)
+	fmt.Fprint(w, heartRate)
 	// fmt.Println(sleepLog.Sleep[0].Data)
 	// fmt.Fprint(w, getResp)
 	// fmt.Println(resp)

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -1,25 +1,26 @@
 package main
 
 import (
+	b64 "encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
+	// "io/ioutil"
 	"os"
-    b64 "encoding/base64"
-    "net/url"
-    "strings"
-
-    // "github.com/satori/go.uuid"
+	"strings"
+	// "github.com/satori/go.uuid"
 )
 
 var params authParams
 
 type authParams struct {
-	client_id string
-    client_secret string
+	client_id     string
+	client_secret string
 	response_type string
-	scope string
-	redirect_uri string
+	scope         string
+	redirect_uri  string
 }
 
 func answer(w http.ResponseWriter, r *http.Request) {
@@ -28,45 +29,164 @@ func answer(w http.ResponseWriter, r *http.Request) {
 }
 
 func register(w http.ResponseWriter, r *http.Request) {
-	var registerUrl = "https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=" + params.client_id + "&scope=sleep"
+	var registerUrl = "https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=" + params.client_id + "&scope=heartrate"
 	http.Redirect(w, r, registerUrl, http.StatusSeeOther)
 }
 
 func concAuth(clientId string, clientSecret string) string {
-    idAndSecret := clientId + ":" + clientSecret
-    return b64.StdEncoding.EncodeToString([]byte(idAndSecret))
+	idAndSecret := clientId + ":" + clientSecret
+	return b64.StdEncoding.EncodeToString([]byte(idAndSecret))
 }
 
-func success(w http.ResponseWriter, r *http.Request)  {
+type HeartRate int64
+type Calorie float64
+
+type Heart struct {
+	ActivitiesHeart         []ActivityHeart         `json:"activities-heart"`
+	ActivitiesHeartIntraday []ActivityHeartIntraday `json:"activities-heart-intraday"`
+}
+
+type ActivityHeart struct {
+	DateTime string             `json:"dateTime"`
+	Value    ActivityHeartValue `json:"value"`
+}
+
+type ActivityHeartValue struct {
+	CustomHeartRateZones []CustomHeartRateZone `json:"customHeartRateZones"`
+	HeartRateZones       []HeartRateZone       `json:"heartRateZones"`
+	RestingHeartRate     HeartRate             `json:"restingHeartRate"`
+}
+
+type CustomHeartRateZone struct {
+	// TODO
+}
+
+type HeartRateZone struct {
+	CaloriesOut Calorie   `json:"caloriesOut"`
+	Max         HeartRate `json:"max"`
+	Min         HeartRate `json:"min"`
+	Minutes     HeartRate `json:"minutes"`
+	Name        string    `json:"name"`
+}
+
+type ActivityHeartIntraday struct {
+	Dataset  []HeartIntradayDatapoint `json:"dataset"`
+	Interval int                      `json:"datasetInterval"`
+	Type     string                   `json:"datasetType"`
+}
+
+type HeartIntradayDatapoint struct {
+	Time      string    `json:"time"`
+	HeartRate HeartRate `json:"value"`
+}
+
+type Sleep struct {
+	Sleep []SleepDatapoint `json:"sleep"`
+}
+
+type SleepDatapoint struct {
+	Data                string      `json:"dateOfSleep"`
+	Duration            int         `json:"duration"`
+	Efficiency          int         `json:"efficiency"`
+	IsMainSleep         bool        `json:"isMainSleep"`
+	Levels              SleepLevels `json:"levels"`
+	LogId               int         `json:"logId"`
+	MinutesAfterWakeup  int         `json:"minutesAfterWakeup"`
+	MinutesAsleep       int         `json:"minutesAsleep"`
+	MinutesAwake        int         `json:"minutesAwake"`
+	MinutesToFallAsleep int         `json:"minutesToFallAsleep"`
+	StartTime           string      `json:"startTime"`
+	TimeInBed           int         `json:"timeInBed"`
+	Type                string      `json:"type"`
+}
+
+type SleepLevels struct {
+	Summary   SleepLevelsSummary     `json:"summary"`
+	Data      []SleepLevelsDatapoint `json:"data"`
+	ShortData []SleepLevelsDatapoint `json:"shortData"`
+}
+
+type SleepLevelsSummary struct {
+	Deep  SleepLevel `json:"deep"`
+	Light SleepLevel `json:"light"`
+	Rem   SleepLevel `json:"rem"`
+	Wake  SleepLevel `json:"wake"`
+}
+type SleepLevel struct {
+	Count           int `json:"count"`
+	Minutes         int `json:"minutes"`
+	AvgMinutes30Day int `json:"thirtyDayAvgMinutes"`
+}
+
+type SleepLevelsDatapoint struct {
+	Datetime string `json:"datetime"`
+	Level    string `json:"level"`
+	Duration int    `json:"seconds"`
+}
+
+func success(w http.ResponseWriter, r *http.Request) {
 	fmt.Print(r)
 	fmt.Fprintf(w, "Received! :)")
 
-    keys, ok := r.URL.Query()["code"]
-    if !ok || len(keys[0]) < 1 {
-        log.Println("Url param 'code' is missing")
-    }
-    fmt.Print(keys)
+	keys, ok := r.URL.Query()["code"]
+	if !ok || len(keys[0]) < 1 {
+		log.Println("Url param 'code' is missing")
+	}
+	fmt.Print(keys)
 
+	authURL := "https://api.fitbit.com/oauth2/token"
+	v := url.Values{}
+	client := &http.Client{}
+	v.Add("client_id", params.client_id)
+	v.Add("grant_type", "authorization_code")
+	v.Add("code", keys[0])
+	req, err := http.NewRequest("POST", authURL, strings.NewReader(v.Encode()))
+	if err != nil {
+		fmt.Println("some Post Err")
+	}
+	req.Header.Set("Authorization", "Basic "+concAuth(params.client_id, params.client_secret))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		fmt.Println("some client Do err")
+	}
+	fmt.Println(resp.Status)
+	type ResponseInfo struct {
+		AccessToken  string `json:"access_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		RefreshToken string `json:"refresh_token"`
+		TokenType    string `json:"token_type"`
+		UserId       string `json:"user_id"`
+	}
+	var accessTokenInfo ResponseInfo
+	err = json.NewDecoder(resp.Body).Decode(&accessTokenInfo)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Println(accessTokenInfo)
 
-    authURL := "https://api.fitbit.com/oauth2/token"
-    v := url.Values{}
-    client := &http.Client{}
-    v.Add("client_id", params.client_id)
-    v.Add("grant_type", "authorization_code")
-    v.Add("code", keys[0])
-    req, err := http.NewRequest("POST", authURL, strings.NewReader(v.Encode()))
-    if err != nil {
-        fmt.Println("some Post Err")
-    }
-    req.Header.Set("Authorization", "Basic " + concAuth(params.client_id, params.client_secret))
-    req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-    resp, err := client.Do(req)
-    if err != nil {
-        fmt.Prntln(err)
-        fmt.Println("some client Do err")
-    }
-    fmt.Println(resp.Status)
-    fmt.Println(resp.Body)
+	reqURL := "https://api.fitbit.com/1.2/user/" + accessTokenInfo.UserId + "/sleep/date/2019-02-22.json"
+	getReq, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		fmt.Println("some get reqq err")
+	}
+	getReq.Header.Set("Authorization", "Bearer "+accessTokenInfo.AccessToken)
+	fmt.Println(getReq)
+	getResp, err := client.Do(getReq)
+	if err != nil {
+		fmt.Println("some client do get req error")
+	}
+	fmt.Println(getResp.Status)
+
+	var sleepLog Sleep
+	//	body, err := ioutil.ReadAll(getResp.Body)
+	//	fmt.Println(string(body))
+	err = json.NewDecoder(getResp.Body).Decode(&sleepLog)
+	fmt.Fprint(w, sleepLog)
+	// fmt.Println(sleepLog.Sleep[0].Data)
+	// fmt.Fprint(w, getResp)
+	// fmt.Println(resp)
 }
 
 func fitbitData(w http.ResponseWriter, r *http.Request) {

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -117,7 +117,7 @@ func getHeartRateData() Heart {
 	if err != nil {
 		fmt.Println("some client do get req error")
 	}
-	fmt.Println(getResp.Status)
+	fmt.Println("hetHeartRateData() says: " + getResp.Status)
 	var heartRateData Heart
 	err = json.NewDecoder(getResp.Body).Decode(&heartRateData)
 	return heartRateData
@@ -195,7 +195,7 @@ func refreshToken() {
 		fmt.Println(err)
 		fmt.Println("some client Do err")
 	}
-	fmt.Println(resp.Status)
+	fmt.Println("refreshToken() says: " + resp.Status)
 	err = json.NewDecoder(resp.Body).Decode(&accessTokenInfo)
 	if err != nil {
 		fmt.Println("error:", err)
@@ -205,7 +205,7 @@ func refreshToken() {
 }
 
 func main() {
-	params = authParams{os.Args[1], os.Args[2]}
+	params = authParams{os.Args[1], os.Args[2], ""}
 
 	http.HandleFunc("/", welcomeMessage)
 	http.HandleFunc("/register/", register)

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"log"
+)
+
+func answer(w http.ResponseWriter, r *http.Request) {
+	fmt.Println(r)
+	fmt.Fprintf(w, "AWAKE")
+}
+
+func fitbitData(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)		
+}
+
+func main() {
+	http.HandleFunc("/", answer)
+	http.HandleFunc("/subscribe/sleep/", fitbitData)
+	err := http.ListenAndServe(":9090", nil)
+	if err != nil {
+		log.Fatal("listenAndServe: ", err)
+	}
+}

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -49,16 +49,16 @@ type HeartRate int64
 type Calorie float64
 
 type Heart struct {
-	ActivitiesHeartIntraday ActivityHeartIntraday `json:"activities-heart-intraday"`
-	ActivitiesHeart 				ActivitiesHeart				`json:"activities-heart"`
+	ActivitiesHeartIntraday ActivityHeartIntraday	`json:"activities-heart-intraday"`
+	ActivitiesHeart		[]ActivitiesHeart		`json:"activities-heart"`
 }
 
 type ActivitiesHeart struct {
-	Dataset  []RestingHeartRate `json:"dataset"`
+	Value Value `json:"value"`
 }
 
-type RestingHeartRate struct {
-	HeartRate HeartRate `json:"restingHeartRate"`
+type Value struct {
+	RestingHeartRate HeartRate `json:"restingHeartRate"`
 }
 
 type ActivityHeartIntraday struct {
@@ -108,11 +108,11 @@ func authOnSuccess(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		fmt.Println("error:", err)
 	} else {
-		authParams.refresh_token = accessTokenInfo.RefreshToken
+		params.refresh_token = accessTokenInfo.RefreshToken
 	}
 	//fmt.Println(accessTokenInfo)
 	heartRate := getHeartRateData()
-	fmt.Fprint(w, heartRate.Heart)
+	fmt.Fprint(w, heartRate)
 	//fmt.Fprint(w, heartRate.ActivitiesHeartIntraday)
 	//fmt.Fprint(w, heartRate.ActivitiesHeart)
 }
@@ -125,6 +125,7 @@ func getHeartRateData() Heart {
 	}
 	getReq.Header.Set("Authorization", "Bearer "+accessTokenInfo.AccessToken)
 	fmt.Println(getReq)
+	client := &http.Client{}
 	getResp, err := client.Do(getReq)
 	if err != nil {
 		fmt.Println("some client do get req error")
@@ -139,16 +140,16 @@ func getHeartRateData() Heart {
 func fitbitData(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
-
+/*
 func refreshToken(w http.ResponseWriter, r *http.Request) {
 	client := &http.Client{}
 
 	v := url.Values{}
 	v.Add("grant_type", "authorization_code")
-	v.Add("refresh_token", authParams.refresh_token)
+	v.Add("refresh_token", params.refresh_token)
 
 	req, err := http.NewRequest("POST", "https://api.fitbit.com/oauth2/token", strings.NewReader(v.Encode()))
-	if err != nill {
+	if err != nil {
 		fmt.Println("Unable to create request.")
 	}
 
@@ -160,8 +161,8 @@ func refreshToken(w http.ResponseWriter, r *http.Request) {
 		fmt.Println(err)
 		fmt.Println("some client Do err")
 	}
-}
-
+}*/
+/*
 func isSleeping(w http.ResponseWriter, r *http.Request) {
 	// Call on register to retrive data from FitBit
 
@@ -175,16 +176,16 @@ func isSleeping(w http.ResponseWriter, r *http.Request) {
 		// return false
 	}
 }
-
+*/
 func main() {
-	params = authParams{os.Args[1], os.Args[2], os.Args[3], os.Args[4], os.Args[5]}
+	params = authParams{os.Args[1], os.Args[2], os.Args[3], os.Args[4], os.Args[5], os.Args[6]}
 
 	http.HandleFunc("/", welcomeMessage)
 	http.HandleFunc("/register/", register)
 	http.HandleFunc("/success/", authOnSuccess)
 	http.HandleFunc("/subscribe/sleep/", fitbitData)
-	http.HandleFunc("/refresh_token/", refreshToken)
-	http.HandleFunc("/is_sleeping/", isSleeping)
+//	http.HandleFunc("/refresh_token/", refreshToken)
+//	http.HandleFunc("/is_sleeping/", isSleeping)
 
 	err := http.ListenAndServeTLS(":443", "/etc/letsencrypt/live/phewstoc.sladic.se/fullchain.pem", "/etc/letsencrypt/live/phewstoc.sladic.se/privkey.pem", nil)
 	if err != nil {

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -22,8 +22,8 @@ func answer(w http.ResponseWriter, r *http.Request) {
 }
 
 func register(w http.ResponseWriter, r *http.Request) {
-	var registerUrl = "https://www.fitbit.com/oauth2/authorize?response_type=code&client_id=" + params.client_id +
-		"&redirect_uri=phewstoc.sladic.se/success/&scope=sleep"
+	var registerUrl = "https://www.fitbit.com/oauth2/authorize?response_type=code&client_id="
+	+ params.client_id + "&scope=sleep"
 	http.Redirect(w, r, registerUrl, http.StatusSeeOther)
 }
 
@@ -44,7 +44,8 @@ func main() {
 	http.HandleFunc("/register/success", success)
 	http.HandleFunc("/subscribe/sleep/", fitbitData)
 
-	err := http.ListenAndServe(":9090", nil)
+	//err := http.ListenAndServeTLS(":9090", "server.crt", "server.key", nil)
+	err := http.listenAndServe("9090")
 	if err != nil {
 		log.Fatal("listenAndServe: ", err)
 	}

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -60,8 +60,9 @@ func success(w http.ResponseWriter, r *http.Request)  {
     }
     req.Header.Set("Authorization", "Basic " + concAuth(params.client_id, params.client_secret))
     req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-    resp, err := client.Do(r)
+    resp, err := client.Do(req)
     if err != nil {
+        fmt.Prntln(err)
         fmt.Println("some client Do err")
     }
     fmt.Println(resp.Status)

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -40,31 +40,7 @@ type HeartRate int64
 type Calorie float64
 
 type Heart struct {
-	ActivitiesHeart         []ActivityHeart         `json:"activities-heart"`
-	ActivitiesHeartIntraday []ActivityHeartIntraday `json:"activities-heart-intraday"`
-}
-
-type ActivityHeart struct {
-	DateTime string             `json:"dateTime"`
-	Value    ActivityHeartValue `json:"value"`
-}
-
-type ActivityHeartValue struct {
-	CustomHeartRateZones []CustomHeartRateZone `json:"customHeartRateZones"`
-	HeartRateZones       []HeartRateZone       `json:"heartRateZones"`
-	RestingHeartRate     HeartRate             `json:"restingHeartRate"`
-}
-
-type CustomHeartRateZone struct {
-	// TODO
-}
-
-type HeartRateZone struct {
-	CaloriesOut Calorie   `json:"caloriesOut"`
-	Max         HeartRate `json:"max"`
-	Min         HeartRate `json:"min"`
-	Minutes     HeartRate `json:"minutes"`
-	Name        string    `json:"name"`
+	ActivitiesHeartIntraday ActivityHeartIntraday `json:"activities-heart-intraday"`
 }
 
 type ActivityHeartIntraday struct {
@@ -123,7 +99,7 @@ func authOnSuccess(w http.ResponseWriter, r *http.Request) {
 	}
 	fmt.Println(accessTokenInfo)
 
-	// reqURL := "https://api.fitbit.com/1/user/" + accessTokenInfo.UserId + "/activities/heart/date/today/1d/1sec.json"
+    reqURL := "https://api.fitbit.com/1/user/" + accessTokenInfo.UserId + "/activities/heart/date/today/1d/1sec/time/05:00/05:01.json"
 	getReq, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
 		fmt.Println("some get reqq err")

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -43,8 +43,7 @@ func main() {
 	http.HandleFunc("/register/success", success)
 	http.HandleFunc("/subscribe/sleep/", fitbitData)
 
-	//err := http.ListenAndServeTLS(":9090", "server.crt", "server.key", nil)
-	err := http.ListenAndServe("443", nil)
+	err := http.ListenAndServeTLS(":443", "/etc/letsencrypt/live/phewstoc.sladic.se/fullchain.pem", "/etc/letsencrypt/live/phewstoc.sladic.se/privkey.pem", nil)
 	if err != nil {
 		log.Fatal("listenAndServe: ", err)
 	}

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 )
 
-var heartRateData Heart
-
 var params authParams
 type authParams struct {
 	client_id     string
@@ -112,8 +110,6 @@ func authOnSuccess(w http.ResponseWriter, r *http.Request) {
 	} else {
 		params.refresh_token = accessTokenInfo.RefreshToken
 	}
-	heartRate := getHeartRateData()
-	fmt.Fprint(w, heartRate)
 }
 
 func getHeartRateData() Heart {
@@ -136,11 +132,13 @@ func getHeartRateData() Heart {
 }
 
 func isSleeping(w http.ResponseWriter, r *http.Request) {
+	var heartRateData Heart
+	heartRate := getHeartRateData()
 
 	lowerbpm := findLowerHeartBeat()
 	upperbpm := findUpperHeartBeat()
 
-	if lowerbpm == nil {
+	if lowerbpm == 999 {
 		w.WriteHeader(http.StatusNoContent)
 	}
 
@@ -151,20 +149,20 @@ func isSleeping(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func findLowerHeartBeat() int {
-	lower := nil
+func findLowerHeartBeat() int64 {
+	lower := 999
 	for _, rate := range heartRateData.ActivityHeartIntraday.HeartIntradayDatapoint.HeartRate {
-		if lower > rate || lower == nil {
+		if lower > rate {
 			lower = rate
 		}
 	}
 	return lower
 }
 
-func findUpperHeartBeat() int {
-	upper := nil
+func findUpperHeartBeat() int64 {
+	upper := -1
 	for _, rate := range heartRateData.ActivityHeartIntraday.HeartIntradayDatapoint.HeartRate {
-		if upper < rate || upper == nil {
+		if upper < rate {
 			upper = rate
 		}
 	}

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -6,17 +6,34 @@ import (
 	"log"
 )
 
+type authParams struct {
+	client_id string
+	response_type string
+	scope string
+	redirect_uri string
+}
+
 func answer(w http.ResponseWriter, r *http.Request) {
 	fmt.Println(r)
 	fmt.Fprintf(w, "AWAKE")
 }
 
+func register(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, registerUrl, http.StatusSeeOther)
+}
+
+func success(w http.ResponseWriter, r *http.Request)  {
+
+}
+
 func fitbitData(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNoContent)		
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func main() {
 	http.HandleFunc("/", answer)
+	http.HandleFunc("/register/", register)
+	http.HandleFunc("/register/success", success)
 	http.HandleFunc("/subscribe/sleep/", fitbitData)
 	err := http.ListenAndServe(":9090", nil)
 	if err != nil {

--- a/fitbit-server/fitbit-server.go
+++ b/fitbit-server/fitbit-server.go
@@ -14,6 +14,7 @@ var params authParams
 
 type authParams struct {
 	client_id string
+    client_secret string
 	response_type string
 	scope string
 	redirect_uri string
@@ -42,13 +43,16 @@ func success(w http.ResponseWriter, r *http.Request)  {
     if err != nil {
         log.Println("Url param 'code' is missing")
     }
+    fmt.Print(keys)
 
-    
 
     authURL := "https://api.fitbit.com/oauth2/token"
-    req, err := http.NewRequest("POST", authURL, )
+    req, err := http.NewRequest("POST", "application/x-www-form-urlencoded", authURL)
     req.Header.Set("Authorization", "Basic " + concAuth(clientId, clientSecret))
-    req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+    v := url.Values{}
+    v.Add("client_id", client_id)
+    v.Add("grant_type", "authorization_code")
+    v.Add("code", keys[0])
 }
 
 func fitbitData(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Server is now responding with 418 if user is asleep, and 200 if awake on the `phewstoc.sladic.se/issleeping/` endpoint. It will also refresh tokens automatically against Fitbit if necessary (actually always, but anyhow... it's done). 
First time one need to register on the `phewstoc.sladic.se/register/` endpoint before accessing data in the /issleeping/ endpoint.